### PR TITLE
doc patch: mention InfluxDB::LineProtocol

### DIFF
--- a/lib/AnyEvent/InfluxDB.pm
+++ b/lib/AnyEvent/InfluxDB.pm
@@ -1378,6 +1378,31 @@ C<time>.
 The required C<on_success> code reference is executed if request was successful,
 otherwise executes the required C<on_error> code reference.
 
+If you do not want to handle all the fine details of the line protocol
+yourself, you can use
+L<InfluxDB::LineProtocol|https://metacpan.org/pod/InfluxDB::LineProtocol>
+to convert a hashref into a properly escaped string suitable to
+passing to C<write>:
+
+    use InfluxDB::LineProtocol qw(data2line);
+    my $line = data2line(
+        'cpu_load',
+        {
+            value => 0.64,
+            sensor => 'top', # no need to escape the string
+        },
+        {
+            host => 'server02',
+            region => 'eu-east',
+        },
+        # no need to get time()
+    );
+    $db->write(
+        ...
+        data => [ $line ]
+    );
+
+
 =cut
 
 sub _to_line {


### PR DESCRIPTION
Here's a small doc patch that adds a pointer to InfluxDB::LineProtocol and shows how to use it to convert a Perl hash into a properly escaped line protocol string.

Somebody will have to generate the correct data. It could be the programmer, but then she needs to remember all the fine details of the line protocol, and implement them correctly in each app. Or it could be one tested and optimized piece of code (whether inlined in AnyEvent::InfluxDB or provided by InfluxDB::LineProtocol does not matter). I think the latter is the better option, which is why we published InfluxDB::LineProtocol.

And I do think (but have not benchmarked) that the costs of converting a small hash into a string while applying some regex and other transformations are small compared to sending the data over the network. So I happily pay the very minor performance hit while making sure we send correct data. Slow and correct always beats fast and wrong :-)

