### PR TITLE
Add LIMIT and OFFSET args to SHOW TAG KEYS/VALUES

### DIFF
--- a/lib/AnyEvent/InfluxDB.pm
+++ b/lib/AnyEvent/InfluxDB.pm
@@ -1609,6 +1609,14 @@ sub show_tag_keys {
         if ( my $cond = $args{where} ) {
             $q .= ' WHERE '. $cond;
         }
+
+        if ( my $limit = $args{limit} ) {
+            $q .= ' LIMIT '. $limit;
+        }
+
+        if ( my $offset = $args{offset} ) {
+            $q .= ' OFFSET '. $offset;
+        }
     }
 
     my $url = $self->_make_url('/query', {
@@ -1658,6 +1666,9 @@ sub show_tag_keys {
 
         where => q{host = 'server02'},
 
+        limit => 10,
+        offset => 3,
+
         # callbacks
         on_success => $cv,
         on_error => sub {
@@ -1674,6 +1685,8 @@ Returns from database C<database> and optional measurement C<measurement>,
 values from a single tag key C<key> or a list of tag keys C<keys>, optionally
 filtered by the C<where> clause, a hash reference with tag keys
 as keys and their unique tag values as values.
+
+C<limit> and C<offset> are also supported modifiers.
 
 The required C<on_success> code reference is executed if request was successful,
 otherwise executes the required C<on_error> code reference.
@@ -1702,6 +1715,14 @@ sub show_tag_values {
 
         if ( my $cond = $args{where} ) {
             $q .= ' WHERE '. $cond;
+        }
+
+        if ( my $limit = $args{limit} ) {
+            $q .= ' LIMIT '. $limit;
+        }
+
+        if ( my $offset = $args{offset} ) {
+            $q .= ' OFFSET '. $offset;
         }
     }
 


### PR DESCRIPTION
LIMIT and OFFSET are supported and can appear independently,
as per the InfluxDB 0.13 documentation.

Signed-off-by: Nick Andrew <nick@nick-andrew.net>