### PR TITLE
Fix "missing tag key" bug

### DIFF
--- a/lib/AnyEvent/InfluxDB.pm
+++ b/lib/AnyEvent/InfluxDB.pm
@@ -367,7 +367,7 @@ sub _to_line {
 
     return $data->{measurement}
         .(
-            $t ?
+            %$t ?
                     ','.
                     join(',',
                         map {


### PR DESCRIPTION
Fixes a bug where if you didn't have tags it would give you
`failed to write to Influx: {"error":"unable to parse 'blah, thing=42': missing tag key"}`