### PR TITLE
Include tags in select result

### DIFF
--- a/lib/AnyEvent/InfluxDB.pm
+++ b/lib/AnyEvent/InfluxDB.pm
@@ -593,10 +593,17 @@ sub select {
                         my $res = $_;
 
                         my $cols = $res->{columns};
+                        my $tags = $res->{tags};
                         my $values = $res->{values};
 
                         +{
                             name => $res->{name},
+                            (
+                                $tags ?
+                                    ( tags => $tags )
+                                    :
+                                    ()
+                            ),
                             values => [
                                 map {
                                     +{


### PR DESCRIPTION
This patch includes the tags returned from the InfluxDB API in the resulting hash when present.